### PR TITLE
chore: bump release of charming-actions to 2.5.0-rc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.0
+        uses: canonical/charming-actions/channel@2.5.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The metadata.yaml file was removed, but the charming-actions requires the metadata.yaml file for versions < 2.5. Bump the version to 2.5.0-rc (no stable release yet) in order to use a version compatible with this change.