### PR TITLE
Removed fixed path from ethtool

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class LldpdCharm(CharmBase):
             subprocess.run(
                 [
                     "sudo",
-                    "/usr/sbin/ethtool",
+                    "ethtool",
                     "--set-priv-flags",
                     nic,
                     "disable-fw-lldp",


### PR DESCRIPTION
Removed fixed path from ethtool call as for older systems that have been upgraded and have not been through the /sbin /usr/sbin merge can have ethtool in a different path and causing the ethtool call to fail.