### PR TITLE
chore(integration): bump libjuju version to <=3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju<=3.3.0,>=3.0
+    juju<=3.6.0,>3.3.0
     pytest
     pytest-operator
     pytest-order


### PR DESCRIPTION
with libjuju 3.3, there is error when running integration test